### PR TITLE
fix rds engine version

### DIFF
--- a/templates/database.template.yaml
+++ b/templates/database.template.yaml
@@ -65,7 +65,7 @@ Resources:
       DBInstanceIdentifier: !Ref RDSDBName
       DBSubnetGroupName: !Ref DBSubnetGroup
       Engine: sqlserver-se
-      EngineVersion: 14.00.3049.1.v1
+      EngineVersion: 14.00.3381.3.v1
       LicenseModel: license-included
       MasterUsername: !Ref RDSUsername
       MasterUserPassword: !Ref RDSPassword


### PR DESCRIPTION
*Issue
URGENT ! Current engine version is no longer available.

Error message received from quickstart deployments
Cannot find version 14.00.3049.1.v1 for sqlserver-se (Service: AmazonRDS; Status Code: 400; Error Code: InvalidParameterCombination; Request ID: 8e0b95e9-12dc-4076-802b-9cf5deaa6d6a; Proxy: null)

*Description of changes:*
Updated engine version to latest SQL 2017 version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
