### PR TITLE
Update Orchestrator to 22.10.0

### DIFF
--- a/templates/ha.template.yaml
+++ b/templates/ha.template.yaml
@@ -249,7 +249,7 @@ Resources:
               - - '#!/bin/bash'
                 - yum update -y
                 - yum install -y wget
-                - 'wget https://download.uipath.com/haa/2022.4.1/Rhel7/get-haa.sh'
+                - 'wget https://download.uipath.com/haa/2022.4.2/Rhel7/get-haa.sh'
                 - chmod +x get-haa.sh
                 - !Join
                   - ' '
@@ -342,7 +342,7 @@ Resources:
               - - '#!/bin/bash'
                 - yum update -y
                 - yum install -y wget
-                - 'wget https://download.uipath.com/haa/2022.4.1/Rhel7/get-haa.sh'
+                - 'wget https://download.uipath.com/haa/2022.4.2/Rhel7/get-haa.sh'
                 - chmod +x get-haa.sh
                 - tries=0
                 - maxTries=12
@@ -453,7 +453,7 @@ Resources:
               - - '#!/bin/bash'
                 - yum update -y
                 - yum install -y wget
-                - 'wget https://download.uipath.com/haa/2022.4.1/Rhel7/get-haa.sh'
+                - 'wget https://download.uipath.com/haa/2022.4.2/Rhel7/get-haa.sh'
                 - chmod +x get-haa.sh
                 - tries=0
                 - maxTries=12

--- a/templates/main.template.yaml
+++ b/templates/main.template.yaml
@@ -891,9 +891,9 @@ Parameters:
   OrchestratorVersion:
     Description: UIPath Orchestrator version.
     Type: String
-    Default: 22.4.3
+    Default: 22.10.0
     AllowedValues:
-      - 22.4.3
+      - 22.10.0
     ConstraintDescription: UIPath Orchestrator version can only contain characters *0–9* and *.* (period).
   OrchestratorInstanceCount:
     Description: Number of UiPath Orchestrator instances (1–20).

--- a/templates/server.template.yaml
+++ b/templates/server.template.yaml
@@ -167,7 +167,7 @@ Resources:
     Properties:
       ServiceToken: !Ref FindAMIFunctionArn
       RegionName: !Ref 'AWS::Region'
-      ImageName: Windows_Server-2019-English-Full-Base-*
+      ImageName: Windows_Server-2022-English-Full-Base-*
       Architecture: x86_64
       VirtualizationType: hvm
       Owners: amazon

--- a/templates/uipath-orchestrator.template.yaml
+++ b/templates/uipath-orchestrator.template.yaml
@@ -809,9 +809,9 @@ Parameters:
   OrchestratorVersion:
     Description: UIPath Orchestrator version.
     Type: String
-    Default: 22.4.3
+    Default: 22.10.0
     AllowedValues:
-      - 22.4.3
+      - 22.10.0
     ConstraintDescription: UIPath Orchestrator version can only contain characters *0–9* and *.* (period).
   OrchestratorInstanceCount:
     Description: Number of UiPath Orchestrator instances (1–20).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Bump Orchestrator version to 22.10.0
- Bump HAA version to 22.4.2
- Bump OS version to Windows Server 2022

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
